### PR TITLE
fix(deps): update requires-python to >=3.10 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "hyperstack-cloud-ansible"
 version = "0.1.0"
 description = "Ansible collection for managing Hyperstack Cloud resources"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {text = "GPL-3.0-or-later"}
 authors = [
     {name = "Davi Mello", email = "davi@ollem.io"}


### PR DESCRIPTION
This change updates the `requires-python` setting in `pyproject.toml` from `>=3.9` to `>=3.10`. This is necessary because `ansible-core 2.17.x` and newer versions require Python 3.10 or higher.

This resolves a dependency conflict encountered in the GitHub Actions CI workflow where `uv` could not find a compatible version of `ansible-core` when considering Python 3.9 for dependency resolution.